### PR TITLE
FR locale: 'rétrogradée' for 'backtracked'

### DIFF
--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -1021,7 +1021,7 @@
     "message": "en attente…"
   },
   "backtracked": {
-    "message": "tracé"
+    "message": "rétrogradée"
   },
   "operationSuccessfullyProcessed": {
     "message": "$type$ traité et confirmé avec succès !",


### PR DESCRIPTION
'tracé' makes no sense in French. (i think it literally means 'plotted')

'rétrogradée' is the correct wording to me, it's also what's used on https://tzstats.com/ when in FR mode.