### PR TITLE
Switched to more widely accepted Chinese terms.

### DIFF
--- a/src/app/templates/LocaleSelect.tsx
+++ b/src/app/templates/LocaleSelect.tsx
@@ -44,13 +44,13 @@ const localeOptions: LocaleOption[] = [
   {
     code: "zh_CN",
     flagName: "cn",
-    label: "Chinese ‒ China (普通话)",
+    label: "Chinese ‒ Simplified (简体中文)",
     disabled: false,
   },
   {
     code: "zh_TW",
     flagName: "tw",
-    label: "Chinese ‒ Taiwan (臺灣話)",
+    label: "Chinese ‒ Traditional (繁體中文)",
     disabled: false,
   },
   {


### PR DESCRIPTION
The terms [Simplified|Traditional] Chinese are more widely used in both Mainland China and Taiwan.

Ideally they wouldn't be accompanied by national flags (Traditional Chinese is also the main language in Hong Kong and Macau) but that's lesser of an issue and I believe it would require a more significant change.