### PR TITLE
Add kDAO to Temple Wallet

### DIFF
--- a/src/lib/temple/assets.ts
+++ b/src/lib/temple/assets.ts
@@ -107,6 +107,16 @@ export const MAINNET_TOKENS: TempleToken[] = [
   },
   {
     type: TempleAssetType.FA1_2,
+    address: "KT1JkoE42rrMBP9b2oDhbx6EUr26GcySZMUH",
+    name: "Kolibri DAO Token",
+    symbol: "kDAO",
+    decimals: 18,
+    fungible: true,
+    iconUrl: "https://kolibri-data.s3.amazonaws.com/kdao-logo.png",
+    status: "displayed",
+  },  
+  {
+    type: TempleAssetType.FA1_2,
     address: "KT1VYsVfmobT7rsMVivvZ4J8i3bPiqz12NaH",
     name: "Wrapped Tezos",
     symbol: "wXTZ",


### PR DESCRIPTION
Howdy Temple Team!

Hover Labs, makers of [Kolibri / kUSD](https://kolibri.finance) are launching a [DAO](https://kolibri-xtz.medium.com/announcing-kolibri-dao-6687eb528cb) with a governance token, `kDAO`. 

This PR whitelists the details of this token into Temple wallet for ease of use. 