### PR TITLE
New domain for api.tez.ie Tezos RPC endpoint

### DIFF
--- a/src/lib/temple/networks.ts
+++ b/src/lib/temple/networks.ts
@@ -67,7 +67,7 @@ export const NETWORKS: TempleNetwork[] = [
     description: "Highly available Tezos Mainnet nodes operated by ECAD Labs",
     lambdaContract: "KT1CPuTzwC7h7uLXd5WQmpMFso1HxrLBUtpE",
     type: "main",
-    rpcBaseURL: "https://api.tez.ie/rpc/mainnet",
+    rpcBaseURL: "https://mainnet.api.tez.ie",
     color: "#047857",
     disabled: false,
   },


### PR DESCRIPTION
At ECAD Labs we recently setup new subdomains for each Tezos network and deprecated the `api.tez.ie/rpc/<network>` endpoint.

The new domains are also referenced in the Taquito docs https://tezostaquito.io/docs/rpc_nodes/#list-of-community-run-nodes