### PR TITLE
Issue 414: Cloudflare Gateway for Images on IPFS

### DIFF
--- a/src/lib/image-uri.ts
+++ b/src/lib/image-uri.ts
@@ -1,4 +1,4 @@
-export const IPFS_GATEWAY = "ipfs.io";
+export const IPFS_GATEWAY = "cloudflare-ipfs.com";
 
 export function formatImgUri(origin: string) {
   if (origin.startsWith("ipfs://")) {


### PR DESCRIPTION
## Issue

https://github.com/madfish-solutions/templewallet-extension/issues/414

Summary: Most images for NFTs (Collectibles) on IPFS are being cold requested, as that owner is the only one looking at the image on a regular basis. Because of this, image requests through the `ipfs.io` gateway take extremely long and our UX times out eventually, displaying no image for the NFT. 

Instead, we should try cloudflare's gateway as it caches more heavily and has better response times on avg.

## Solution

Use Cloudflare's gateway instead in order to speed up image retrieval.

## Documentation

https://developers.cloudflare.com/distributed-web/ipfs-gateway