### PR TITLE
Add 127.0.0.1 to the content_scripts injection whitelist

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -73,7 +73,7 @@
 
   "content_scripts": [
     {
-      "matches": ["http://localhost/*", "https://*/*"],
+      "matches": ["http://localhost/*", "http://127.0.0.1/*", "https://*/*"],
       "js": ["scripts/contentScript.js"],
       "run_at": "document_start",
       "all_frames": true


### PR DESCRIPTION
Hey friends, the recent temple wallet update broke our development lifecycle a bit, so this PR fixes things (which shouldn't alter the security story from your audit).

This ensures that temple wallet will still load on pages hosted at `127.0.0.1` in addition to `localhost`.