### PR TITLE
Improve crypto security. Migrate legacy crypto storage

### DIFF
--- a/src/lib/temple/back/safe-storage.ts
+++ b/src/lib/temple/back/safe-storage.ts
@@ -9,20 +9,43 @@ interface EncryptedStorage {
 }
 
 export async function isStored(storageKey: string) {
-  const items = await browser.storage.local.get([storageKey]);
-  return items[storageKey] !== undefined;
+  storageKey = await wrapStorageKey(storageKey);
+
+  const value = await getPlain(storageKey);
+  return value !== undefined;
 }
 
 export async function fetchAndDecryptOne<T>(storageKey: string, passKey: CryptoKey) {
-  const encStorage = await fetchEncryptedOne(storageKey);
-  return decrypt<T>(encStorage, passKey);
+  storageKey = await wrapStorageKey(storageKey);
+
+  const payload = await fetchEncryptedOne<string>(storageKey);
+
+  let cursor = 0;
+  const [saltHex, iv, dt] = [64, 32, -1].map(length =>
+    payload.slice(cursor, length !== -1 ? (cursor += length) : undefined)
+  );
+
+  const encrypted = { dt, iv };
+  const salt = Buffer.from(saltHex, 'hex');
+
+  const derivedPassKey = await Passworder.deriveKey(passKey, salt);
+  return Passworder.decrypt<T>(encrypted, derivedPassKey);
 }
 
 export async function encryptAndSaveMany(items: [string, any][], passKey: CryptoKey) {
   const encItems = await Promise.all(
     items.map(async ([storageKey, stuff]) => {
-      const encStorage = await encrypt(stuff, passKey);
-      return [storageKey, encStorage] as [typeof storageKey, typeof encStorage];
+      storageKey = await wrapStorageKey(storageKey);
+
+      const salt = Passworder.generateSalt();
+
+      const derivedPassKey = await Passworder.deriveKey(passKey, salt);
+      const { dt, iv } = await Passworder.encrypt(stuff, derivedPassKey);
+
+      const saltHex = Buffer.from(salt).toString('hex');
+      const toSave = [saltHex, iv, dt].join('');
+
+      return [storageKey, toSave] as [typeof storageKey, typeof toSave];
     })
   );
 
@@ -30,37 +53,28 @@ export async function encryptAndSaveMany(items: [string, any][], passKey: Crypto
 }
 
 export async function removeMany(keys: string[]) {
-  await browser.storage.local.remove(keys);
+  await browser.storage.local.remove(await Promise.all(keys.map(wrapStorageKey)));
 }
 
-async function encrypt(stuff: any, passKey: CryptoKey) {
-  const salt = Passworder.generateSalt();
-  const derivedPassKey = await Passworder.deriveKey(passKey, salt);
-  const encrypted = await Passworder.encrypt(stuff, derivedPassKey);
-
-  return {
-    encrypted,
-    salt: Buffer.from(salt).toString('hex')
-  };
+export async function getPlain<T>(key: string): Promise<T | undefined> {
+  const items = await browser.storage.local.get([key]);
+  return items[key];
 }
 
-async function decrypt<T>(encStorage: EncryptedStorage, passKey: CryptoKey) {
-  const { salt: saltHex, encrypted } = encStorage;
-  const salt = Buffer.from(saltHex, 'hex');
-  const derivedPassKey = await Passworder.deriveKey(passKey, salt);
-  return Passworder.decrypt<T>(encrypted, derivedPassKey);
+export function savePlain<T>(key: string, value: T) {
+  return browser.storage.local.set({ [key]: value });
 }
 
-async function fetchEncryptedOne(key: string) {
+async function fetchEncryptedOne<T>(key: string) {
   const items = await browser.storage.local.get([key]);
   if (items[key] !== undefined) {
-    return items[key] as EncryptedStorage;
+    return items[key] as T;
   } else {
     throw new Error('Some storage item not found');
   }
 }
 
-async function saveEncrypted(items: { [k: string]: EncryptedStorage } | [string, EncryptedStorage][]) {
+async function saveEncrypted<T>(items: { [k: string]: T } | [string, T][]) {
   if (Array.isArray(items)) {
     items = iterToObj(items);
   }
@@ -73,4 +87,56 @@ function iterToObj(iter: [string, any][]) {
     obj[k] = v;
   }
   return obj;
+}
+
+async function wrapStorageKey(key: string) {
+  const bytes = await crypto.subtle.digest('SHA-256', Buffer.from(key, 'utf-8'));
+  return Buffer.from(bytes).toString('hex');
+}
+
+/**
+ * @deprecated
+ */
+export async function isStoredLegacy(storageKey: string) {
+  const value = await getPlain(storageKey);
+  return value !== undefined;
+}
+
+/**
+ * @deprecated
+ */
+export async function removeManyLegacy(keys: string[]) {
+  await browser.storage.local.remove(keys);
+}
+
+/**
+ * @deprecated
+ */
+export async function fetchAndDecryptOneLegacy<T>(storageKey: string, passKey: CryptoKey) {
+  const { salt: saltHex, encrypted } = await fetchEncryptedOne<EncryptedStorage>(storageKey);
+  const salt = Buffer.from(saltHex, 'hex');
+  const derivedPassKey = await Passworder.deriveKeyLegacy(passKey, salt);
+  return Passworder.decrypt<T>(encrypted, derivedPassKey);
+}
+
+/**
+ * @deprecated
+ */
+export async function encryptAndSaveManyLegacy(items: [string, any][], passKey: CryptoKey) {
+  const encItems = await Promise.all(
+    items.map(async ([storageKey, stuff]) => {
+      const salt = Passworder.generateSalt();
+      const derivedPassKey = await Passworder.deriveKeyLegacy(passKey, salt);
+      const encrypted = await Passworder.encrypt(stuff, derivedPassKey);
+
+      const encStorage = {
+        encrypted,
+        salt: Buffer.from(salt).toString('hex')
+      };
+
+      return [storageKey, encStorage] as [typeof storageKey, typeof encStorage];
+    })
+  );
+
+  await saveEncrypted(encItems);
 }


### PR DESCRIPTION
Improve crypto security
Migrate legacy crypto storage
New crypto updates:
- Use password hash in memory when unlocked(instead of plain password)
 - Wrap storage keys in sha256(instead of plain)
- Concat storage values to bytes(instead of json)
- Increase PBKDF rounds