### PR TITLE
Message signing preview overflow and \n parse

### DIFF
--- a/src/app/templates/OperationView.tsx
+++ b/src/app/templates/OperationView.tsx
@@ -107,7 +107,7 @@ const OperationView: FC<OperationViewProps> = ({ payload, networkRpc, mainnet = 
         <OperationsBanner
           opParams={payload.preview}
           className={classNames(spFormat.key !== 'raw' && 'hidden')}
-          jsonViewStyle={{ height: '11rem' }}
+          jsonViewStyle={{ height: '11rem', maxHeight: '100%', overflow: 'auto' }}
         />
 
         <RawPayloadView

--- a/src/app/templates/OperationsBanner.tsx
+++ b/src/app/templates/OperationsBanner.tsx
@@ -82,7 +82,9 @@ const OperationsBanner = memo<OperationsBannerProps>(
             }}
           >
             {typeof opParams === 'string' ? (
-              <div className={classNames('p-1', 'text-lg text-gray-700 font-normal')}>{opParams}</div>
+              <div className={classNames('p-1', 'text-lg text-gray-700 font-normal whitespace-pre-line')}>
+                {opParams}
+              </div>
             ) : (
               <ReactJson
                 src={opParams}


### PR DESCRIPTION
fix Message signing: raw doesn't shows \n characters correctly #442 and #440