### PR TITLE
Renamed "Raum" to "Freie Kapazität". "Raum" is a poor translation from "Space".

### DIFF
--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -876,7 +876,7 @@
     "message": "Gebühr"
   },
   "space": {
-    "message": "Raum"
+    "message": "Freie Kapazität"
   },
   "delegation": {
     "message": "Delegation"


### PR DESCRIPTION
Renamed "Raum" to "Freie Kapazität". "Raum" is a poor translation from "Space".
