### PR TITLE
[Fix] Asset icon fit the select

### DIFF
--- a/src/app/templates/AssetIcon.tsx
+++ b/src/app/templates/AssetIcon.tsx
@@ -44,7 +44,12 @@ export const AssetIcon: FC<AssetIconProps> = ({ assetSlug, className, size }) =>
         <img
           src={imageSrc}
           alt={metadata?.name}
-          style={!isLoaded ? { display: 'none' } : {}}
+          style={{
+            ...(!isLoaded ? { display: 'none' } : {}),
+            objectFit: 'contain',
+            maxWidth: `${size}px`,
+            maxHeight: `${size}px`
+          }}
           height={size}
           width={size}
           onLoad={() => setIsLoaded(true)}


### PR DESCRIPTION
https://www.notion.so/madfissolutions/The-token-icon-goes-beyond-the-Asset-dropdown-in-Send-page-1a1448de51fd450e817d03a8dff15442