### PR TITLE
Explore-Header icons allign

### DIFF
--- a/src/app/layouts/PageLayout.tsx
+++ b/src/app/layouts/PageLayout.tsx
@@ -213,7 +213,7 @@ const Toolbar: FC<ToolbarProps> = ({ pageTitle, hasBackAction = true, step, setS
             href="https://templewallet.com/download"
             target="_blank"
             rel="noopener noreferrer"
-            className="mr-8 my-auto"
+            className="mr-3 my-auto"
             onClick={handleDownloadMobileIconClick}
           >
             {isTempleMobileOverlaySkipped ? <DownloadMobileIcon /> : <DownloadMobileGreyIcon />}

--- a/src/app/layouts/PageLayout.tsx
+++ b/src/app/layouts/PageLayout.tsx
@@ -208,7 +208,7 @@ const Toolbar: FC<ToolbarProps> = ({ pageTitle, hasBackAction = true, step, setS
 
       <div className="flex-1" />
       {attention && (
-        <div className="flex content-end">
+        <div className="flex content-end absolute right-0">
           <a
             href="https://templewallet.com/download"
             target="_blank"

--- a/src/app/layouts/PageLayout.tsx
+++ b/src/app/layouts/PageLayout.tsx
@@ -200,7 +200,7 @@ const Toolbar: FC<ToolbarProps> = ({ pageTitle, hasBackAction = true, step, setS
       {pageTitle && (
         <h2
           className={classNames('px-1', 'flex items-center', 'text-gray-700', 'font-normal leading-none')}
-          style={attention ? { marginLeft: 40, fontSize: 17 } : { fontSize: 17 }}
+          style={{ fontSize: 17 }}
         >
           {pageTitle}
         </h2>


### PR DESCRIPTION
https://www.notion.so/madfissolutions/Reduce-indents-between-Mobile-icon-and-Warning-icon-on-the-Home-page-63dcf56c8a3f4aab8e9ebd405161c846