### PR TITLE
Faucet link update in the import prompt

### DIFF
--- a/src/app/pages/ImportAccount.tsx
+++ b/src/app/pages/ImportAccount.tsx
@@ -657,13 +657,13 @@ const FromFaucetForm: FC = () => {
                 id="faucetFileInputPrompt"
                 substitutions={[
                   <a
-                    href="https://faucet.tzalpha.net/"
+                    href="https://teztnets.xyz/"
                     key="link"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="font-normal underline"
                   >
-                    https://faucet.tzalpha.net
+                    https://teztnets.xyz/
                   </a>
                 ]}
               />


### PR DESCRIPTION
In the faucet import prompt, the TzAlpha link no longer works.
[Teztnet faucets](https://teztnets.xyz/) is used by everyone now and it's also updated in the [Tezos Developer Portal](https://tezos.com/developer-portal/)