### PR TITLE
Add Flashbake Endpoints

### DIFF
--- a/src/lib/temple/networks.ts
+++ b/src/lib/temple/networks.ts
@@ -54,6 +54,24 @@ export const NETWORKS: TempleNetwork[] = [
     disabled: false
   },
   {
+    id: 'flashbake-mainnet',
+    name: 'Flashbake Mainnet',
+    description: 'A private mempool relay for Tezos Mainnet. Learn more: flashbake.xyz',
+    type: 'main',
+    rpcBaseURL: 'https://relay.flashbake.xyz',
+    color: '#2e8555',
+    disabled: false
+  },
+  {
+    id: 'flashbake-testnet',
+    name: 'Flashbake Testnet',
+    description: 'A private mempool relay for Tezos Testnet. Learn more: flashbake.xyz',
+    type: 'test',
+    rpcBaseURL: 'https://ghostnet.relay.flashbake.xyz',
+    color: '#60b582',
+    disabled: false
+  },
+  {
     id: 't4l3nt-testnet',
     name: 'T4L3NT Testnet',
     description: 'Decentralized pictures testnet',


### PR DESCRIPTION
[Flashbake](https://flashbake.xyz) is a private relay for Tezos node operators. The functionality is similar to [Flashbots Protect](https://docs.flashbots.net/flashbots-protect/rpc/quick-start/). 

Users submit a transaction to the Flashbake relay (this endpoint) which looks like a Tezos node, but is really a program running an offchain auction. The relay will ferry the transaction to the next flashbaker if the transaction wins. If there is no flashbaker in the next two hours, or the transaction never wins the auction, it will eventually time out. 

This might present usability issues given that users will need to understand what they're using. If you are interested in including these networks but there's additional legwork you'd like done, let us know and we can try to assist.