### PR TITLE
TW-880: use new loadProtocols to fetch the protocol and set the localForger on send operation

### DIFF
--- a/src/lib/temple/helpers.ts
+++ b/src/lib/temple/helpers.ts
@@ -15,9 +15,19 @@ export const loadChainId = memoize(fetchChainId, {
   maxSize: 100
 });
 
+export const loadProtocols = memoize(fetchProtocols, {
+  isPromise: true,
+  maxSize: 100
+});
+
 function fetchChainId(rpcUrl: string) {
   const rpc = new RpcClient(rpcUrl);
   return rpc.getChainId();
+}
+
+function fetchProtocols(rpcUrl: string) {
+  const rpc = new RpcClient(rpcUrl);
+  return rpc.getProtocols({ block: 'head' });
 }
 
 export function hasManager(manager: ManagerKeyResponse) {


### PR DESCRIPTION
Fetch the protocol and set the localForger for the selected network protocol to avoid the "Forging mismatch" error when the protocol of the node does not match the default protocol of taquito local-forging.

Please let me know any recommended changes and I'll refactor.  Thanks!